### PR TITLE
Issue 6: Add basic auth

### DIFF
--- a/packages/cli-utils/src/index.js
+++ b/packages/cli-utils/src/index.js
@@ -239,7 +239,7 @@ const emptyS3Bucket = async (AWS, bucket, prefix) => {
 // Cloudformation utils
 // ---------------------------------------------------
 
-const paramsToInquirer = (params, opts = {}) => {
+const paramsToInquirer = (params, defaults = {}) => {
   const questions = [];
   Object.keys(params).forEach(key => {
     const obj = params[key];
@@ -247,7 +247,7 @@ const paramsToInquirer = (params, opts = {}) => {
       name: key,
       type: obj.AllowedValues ? "list" : "input",
       message: obj.Description || key,
-      default: obj.Default || opts.default,
+      default: obj.Default || defaults[key],
       choices: obj.AllowedValues
     });
   });

--- a/packages/cli-utils/test/expectations.js
+++ b/packages/cli-utils/test/expectations.js
@@ -33,11 +33,27 @@ const expectCreateStack = (aws, stackName) => {
   return [calls[0], tmpl];
 };
 
+const expectUpdateStack = (aws, stackName) => {
+  const { calls } = aws.mockCloudformation.updateStack.mock;
+  expect(calls.length).toBe(1);
+  expect(calls[0][0].StackName).toEqual(stackName);
+  const tmpl = JSON.parse(calls[0][0].TemplateBody);
+  return [calls[0], tmpl];
+};
+
 const expectDeleteStack = (aws, stackName) => {
   const { calls } = aws.mockCloudformation.deleteStack.mock;
   expect(calls.length).toBe(1);
   expect(calls[0][0].StackName).toEqual(stackName);
   return calls[0];
+};
+
+const expectParameters = (actual, desired) => {
+  const desiredObj = Object.keys(desired).map(key => ({
+    ParameterKey: key,
+    ParameterValue: desired[key]
+  }));
+  expect(actual).toEqual(desiredObj);
 };
 
 module.exports = {
@@ -46,5 +62,7 @@ module.exports = {
   expectDeleteEnvironmentConfig,
   expectEmptyS3Bucket,
   expectCreateStack,
-  expectDeleteStack
+  expectUpdateStack,
+  expectDeleteStack,
+  expectParameters
 };

--- a/packages/cli-utils/test/mock.js
+++ b/packages/cli-utils/test/mock.js
@@ -60,6 +60,7 @@ const mockUtils = (mod, ret = {}) => {
 
   const mockCloudformation = {
     createStack: func(val(ret, "createStack", { StackId: 1 })),
+    updateStack: func(val(ret, "updateStack", { StackId: 1 })),
     deleteStack: func(val(ret, "deleteStack")),
     createChangeSet: func(val(ret, "createChangeSet")),
     executeChangeSet: func(val(ret, "executeChangeSet")),

--- a/packages/static/README.md
+++ b/packages/static/README.md
@@ -4,7 +4,8 @@ This is a simple, opinionated command-line client that takes the pain out of dep
 
 Features:
 
-- **Automated CloudFormation**. The tool will create an S3 bucket and CloudFront distribution with healthy defaults such a CORS and HTTPS to serve your static website.
+- **Creation of resources via CloudFormation**. The tool will create an S3 bucket and CloudFront distribution with healthy defaults such a CORS and HTTPS to serve your static website.
+- **Basic auth**. You can optionally hide the website behind basic authentication using a Lambda Edge function attached to the CloudFront distribution. This can be set per environment, and is automatically provisioned for you.
 - **Multiple environments**. Deploy different versions of your website based on your Git branches. This allows you to e.g. have a `staging` and `production` environment for the same website.
 - **File metadata**. Easily customize the `cache-control` header for specific file types, or any other metadata supported by S3.
 - **AWS profiles**. Use a named profile in your AWS credentials file, or just use the AWS environment variables to authenticate with an AWS account.
@@ -26,7 +27,7 @@ $ static init
 
 ## Deploying
 
-To upload a site, run the `deploy` command. If this is the first time you are running the command, a new environment will be set up based on your Git branch. Then, it will upload all files in the specified build folder to the environment's S3 bucket.
+To upload a website, run the `deploy` command. If this is the first time you are running the command on this Git branch, `static` will prompt a number of questions about the new environment, and a new CloudFormation stack with the needed resources will be created based on the answers.
 
 ```
 $ static deploy
@@ -36,6 +37,12 @@ You can optionally run the command with a `--env` parameter to ignore the Git br
 
 ```
 $ static deploy --env somename
+```
+
+If you at any time want to reconfigure the environment, run the command with the `--configure` parameter to rerun the deployment prompts.
+
+```
+$ static deploy --configure
 ```
 
 ## Configuration file

--- a/packages/static/src/cli.js
+++ b/packages/static/src/cli.js
@@ -20,7 +20,10 @@ require("yargs")
     "deploy",
     "Deploys the website",
     yargs => {
-      yargs.option("env", env);
+      yargs.option("env", env).option("configure", {
+        describe: "Reconfigure the CloudFormation stack",
+        type: "boolean"
+      });
     },
     deploy
   )

--- a/packages/static/src/cloudformation/auth.json
+++ b/packages/static/src/cloudformation/auth.json
@@ -1,0 +1,84 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+
+  "Description": "AWS CloudFormation template to set up basic auth for CloudFront distribution",
+
+  "Parameters": {
+    "AuthUsername": {
+      "Description": "Username to be used for basic authentication",
+      "Type": "String"
+    },
+    "AuthPassword": {
+      "Description": "Password to be used for basic authentication",
+      "Type": "String"
+    }
+  },
+
+  "Resources": {
+    "AuthLambdaRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": { "Fn::Sub": "${environment}-auth-lambda" },
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": ["lambda.amazonaws.com", "edgelambda.amazonaws.com"]
+              },
+              "Action": ["sts:AssumeRole"]
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "root",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Resource": "arn:aws:logs:*:*:*",
+                  "Action": "logs:*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+
+    "AuthLambda": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "FunctionName": {
+          "Fn::Sub": "${environment}-auth-lambda"
+        },
+        "Description": "Lambda function to provide basic auth for a CloudFront distribution",
+        "Code": {
+          "ZipFile": {
+            "Fn::Sub": "'use strict'; exports.handler = (event, context, callback) => { const request = event.Records[0].cf.request; const headers = request.headers; const authUser = '${AuthUsername}'; const authPass = '${AuthPassword}'; const authString = 'Basic ' + new Buffer(authUser + ':' + authPass).toString('base64'); if (typeof headers.authorization == 'undefined' || headers.authorization[0].value != authString) { const body = 'Unauthorized'; const response = { status: '401', statusDescription: 'Unauthorized', body: body, headers: { 'www-authenticate': [{key: 'WWW-Authenticate', value:'Basic'}] } }; callback(null, response); } callback(null, request); };"
+          }
+        },
+        "MemorySize": 128,
+        "Timeout": 5,
+        "Runtime": "nodejs10.x",
+        "Handler": "index.handler",
+        "Role": { "Fn::GetAtt": ["AuthLambdaRole", "Arn"] }
+      }
+    },
+
+    "AuthLambdaLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": ["/", ["/aws/lambda", { "Ref": "AuthLambda" }]]
+        },
+        "RetentionInDays": 30
+      }
+    }
+  },
+
+  "Outputs": {}
+}

--- a/packages/static/src/cloudformation/auth.json
+++ b/packages/static/src/cloudformation/auth.json
@@ -69,6 +69,13 @@
       }
     },
 
+    "VersionedAuthLambda": {
+      "Type": "AWS::Lambda::Version",
+      "Properties": {
+        "FunctionName": { "Ref": "AuthLambda" }
+      }
+    },
+
     "AuthLambdaLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {

--- a/packages/static/src/cloudformation/cloudfront.json
+++ b/packages/static/src/cloudformation/cloudfront.json
@@ -39,6 +39,7 @@
             "TargetOriginId": "s3-website-origin",
             "MaxTTL": 31536000,
             "MinTTL": 0,
+            "Compress": true,
             "ViewerProtocolPolicy": "redirect-to-https",
             "ForwardedValues": {
               "Cookies": {

--- a/packages/static/src/commands/deploy.js
+++ b/packages/static/src/commands/deploy.js
@@ -9,27 +9,29 @@ const {
   getAWSWithProfile,
   monitorStack,
   logTable,
-  uploadDirToS3
+  uploadDirToS3,
+  paramsToInquirer
 } = require("@designsystemsinternational/cli-utils");
 const {
   ACTION_NO_CONFIG
 } = require("@designsystemsinternational/cli-utils/src/constants");
 const s3Template = require("../cloudformation/s3.json");
 const cloudfrontTemplate = require("../cloudformation/cloudfront.json");
+const authTemplate = require("../cloudformation/auth.json");
 const { defaultFileParams } = require("../utils");
 
 // Main
 // ---------------------------------------------------------------------
 
-const deploy = async args => {
+const deploy = async (args = {}) => {
   const { conf, packageJson } = loadConfig("static");
   if (!conf) {
     throw ACTION_NO_CONFIG;
   }
   const env = args && args.env ? args.env : await getEnvironment();
   const envConf = getEnvironmentConfig(conf, env);
-  if (!envConf) {
-    await createStack(env, conf, packageJson);
+  if (!envConf || args.configure) {
+    await runCloudFormation(env, conf, packageJson, envConf);
   } else {
     await uploadFiles(env, conf, packageJson, envConf);
   }
@@ -38,101 +40,136 @@ const deploy = async args => {
 // Create Stack
 // ---------------------------------------------------------------------
 
-const createStack = async (env, conf, packageJson) => {
+const runCloudFormation = async (env, conf, packageJson, envConf) => {
   const AWS = getAWSWithProfile(conf.profile, conf.region);
-  console.log("Creating new environment:", env);
-
-  const initAnswers = await inquirer.prompt([
+  const answers = await inquirer.prompt([
     {
       type: "input",
-      name: "stackName",
+      name: "stack",
       message: `Name of the new Cloudformation stack`,
-      default: `${packageJson.name}-${env}`
+      default: `${packageJson.name}-${env}`,
+      when: !envConf || !envConf.stack
     },
     {
       type: "confirm",
+      name: "auth",
+      message:
+        "Enable basic authentication? (requires CloudFront distribution)",
+      default: false
+    },
+    {
+      type: "confirm",
+      when: a => !a.auth,
       name: "createCloudfront",
       message: "Do you want to set up a Cloudfront distribution?",
       default: true
     }
   ]);
 
-  // We don't prompt for these Cloudformation params,
-  // but simply rely on their default values.
-  const dontAsk = [];
-
-  // These default values are used in question prompts.
-  // If a parameter is also in dontAsk, this default will
-  // be passed directly to CloudFormation.
-  const dynamicDefaults = {
-    S3BucketName: initAnswers.stackName
-  };
+  const stack = answers.stack || envConf.stack;
 
   // Combine cloudformation templates if needed
   // We perform a somewhat deep copy to not mess up the tests.
-  const createTemplate = {};
-  createTemplate.Parameters = Object.assign({}, s3Template.Parameters);
-  createTemplate.Resources = Object.assign({}, s3Template.Resources);
-  createTemplate.Outputs = Object.assign({}, s3Template.Outputs);
-  if (initAnswers.createCloudfront) {
-    Object.assign(createTemplate.Parameters, cloudfrontTemplate.Parameters);
-    Object.assign(createTemplate.Resources, cloudfrontTemplate.Resources);
-    Object.assign(createTemplate.Outputs, cloudfrontTemplate.Outputs);
+  const template = {};
+  template.Parameters = Object.assign({}, s3Template.Parameters);
+  template.Resources = Object.assign({}, s3Template.Resources);
+  template.Outputs = Object.assign({}, s3Template.Outputs);
+  if (answers.createCloudfront || answers.auth) {
+    Object.assign(template.Parameters, cloudfrontTemplate.Parameters);
+    Object.assign(template.Resources, cloudfrontTemplate.Resources);
+    Object.assign(template.Outputs, cloudfrontTemplate.Outputs);
+    if (answers.auth) {
+      Object.assign(template.Parameters, authTemplate.Parameters);
+      Object.assign(template.Resources, authTemplate.Resources);
+      Object.assign(template.Outputs, authTemplate.Outputs);
+      // We don't have any template logic, so I just inject this here.
+      template.Resources.CloudfrontDistribution.Properties.DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations = [
+        {
+          EventType: "viewer-request",
+          LambdaFunctionARN: { "Fn::GetAtt": ["AuthLambdaRole", "Arn"] }
+        }
+      ];
+    }
   }
 
+  // Dynamic default values for the parameter questions.
+  const defaults = {
+    S3BucketName: envConf ? envConf.bucket : answers.stack
+  };
+
   // Add questions based on Cloudformation parameters
-  const templateQuestions = Object.keys(createTemplate.Parameters)
-    .filter(key => !dontAsk.includes(key))
-    .map(key => {
-      const obj = createTemplate.Parameters[key];
-      return {
-        name: key,
-        type: obj.AllowedValues ? "list" : "input",
-        message: obj.Description,
-        default: dynamicDefaults[key] || obj.Default,
-        choices: obj.AllowedValues
-      };
-    });
+  const templateAnswers = await inquirer.prompt(
+    paramsToInquirer(template.Parameters, defaults)
+  );
 
-  const templateAnswers = await inquirer.prompt(templateQuestions);
-  const parameters = Object.assign({}, dynamicDefaults, templateAnswers);
+  const label = envConf ? "Updating stack" : "Creating stack";
+  const spinner = ora(label).start();
+  const parameters = Object.assign({}, defaults, templateAnswers);
 
-  const spinner = ora("Creating stack").start();
+  // Automatic parameters
+  template.Parameters["environment"] = {
+    Description: "Stack environment based on Git branch",
+    Type: "String"
+  };
+  parameters.environment = env;
 
   const cloudformation = new AWS.CloudFormation();
-  const create = await cloudformation
-    .createStack({
-      StackName: initAnswers.stackName,
-      Parameters: Object.keys(parameters).map(key => ({
-        ParameterKey: key,
-        ParameterValue: parameters[key].toString()
-      })),
-      TemplateBody: JSON.stringify(createTemplate),
-      Capabilities: ["CAPABILITY_NAMED_IAM"]
-    })
-    .promise();
 
-  const created = await cloudformation
-    .waitFor("stackCreateComplete", {
-      StackName: initAnswers.stackName
-    })
-    .promise();
+  let operation;
+
+  if (!envConf) {
+    operation = await cloudformation
+      .createStack({
+        StackName: stack,
+        Parameters: Object.keys(parameters).map(key => ({
+          ParameterKey: key,
+          ParameterValue: parameters[key].toString()
+        })),
+        TemplateBody: JSON.stringify(template),
+        Capabilities: ["CAPABILITY_NAMED_IAM"]
+      })
+      .promise();
+
+    const created = await cloudformation
+      .waitFor("stackCreateComplete", {
+        StackName: stack
+      })
+      .promise();
+  } else {
+    operation = await cloudformation
+      .updateStack({
+        StackName: stack,
+        Parameters: Object.keys(parameters).map(key => ({
+          ParameterKey: key,
+          ParameterValue: parameters[key].toString()
+        })),
+        TemplateBody: JSON.stringify(template),
+        Capabilities: ["CAPABILITY_NAMED_IAM"]
+      })
+      .promise();
+
+    const updated = await cloudformation
+      .waitFor("stackUpdateComplete", {
+        StackName: stack
+      })
+      .promise();
+  }
 
   spinner.succeed();
 
   spinner.start("Saving environment config");
   saveEnvironmentConfig("static", env, {
-    stack: initAnswers.stackName,
+    stack,
     bucket: parameters.S3BucketName,
     fileParams: defaultFileParams
   });
   spinner.succeed();
 
   // Listen for changes to cloudformation
-  await monitorStack(AWS, create.StackId);
+  await monitorStack(AWS, operation.StackId);
 
   const stacks = await cloudformation
-    .describeStacks({ StackName: initAnswers.stackName })
+    .describeStacks({ StackName: stack })
     .promise();
 
   logTable(

--- a/packages/static/src/commands/deploy.js
+++ b/packages/static/src/commands/deploy.js
@@ -30,6 +30,7 @@ const deploy = async (args = {}) => {
   }
   const env = args && args.env ? args.env : await getEnvironment();
   const envConf = getEnvironmentConfig(conf, env);
+
   if (!envConf || args.configure) {
     await runCloudFormation(env, conf, packageJson, envConf);
   } else {
@@ -86,7 +87,7 @@ const runCloudFormation = async (env, conf, packageJson, envConf) => {
       template.Resources.CloudfrontDistribution.Properties.DistributionConfig.DefaultCacheBehavior.LambdaFunctionAssociations = [
         {
           EventType: "viewer-request",
-          LambdaFunctionARN: { "Fn::GetAtt": ["AuthLambdaRole", "Arn"] }
+          LambdaFunctionARN: { Ref: "VersionedAuthLambda" }
         }
       ];
     }

--- a/packages/static/test/commands/deploy/deploy.create.test.js
+++ b/packages/static/test/commands/deploy/deploy.create.test.js
@@ -94,6 +94,32 @@ describe("deploy", () => {
       });
     });
 
+    it("uses dynamic defaults for inquirer prompt", async () => {
+      inquirer.prompt
+        .mockResolvedValueOnce({
+          stack: "stack-test",
+          createCloudfront: true
+        })
+        .mockResolvedValueOnce({
+          S3BucketName: "test-bucket",
+          IndexPage: "index.html",
+          ErrorPage: "index.html"
+        });
+
+      const deploy = require("../../../src/commands/deploy");
+      await deploy();
+
+      const { calls } = inquirer.prompt.mock;
+      expect(calls[0][0][0]).toMatchObject({
+        name: "stack",
+        default: "fake-package-test"
+      });
+      expect(calls[1][0][0]).toMatchObject({
+        name: "S3BucketName",
+        default: "stack-test"
+      });
+    });
+
     it("does not create cloudfront", async () => {
       inquirer.prompt
         .mockResolvedValueOnce({

--- a/packages/static/test/commands/deploy/deploy.test.js
+++ b/packages/static/test/commands/deploy/deploy.test.js
@@ -1,19 +1,17 @@
 const utils = require("@designsystemsinternational/cli-utils");
 const {
-  ACTION_NO_CONFIG,
+  ACTION_NO_CONFIG
 } = require("@designsystemsinternational/cli-utils/src/constants");
 const {
-  mockUtils,
+  mockUtils
 } = require("@designsystemsinternational/cli-utils/test/mock");
 
 describe("deploy", () => {
-  describe("deploy", () => {
-    it("fails if no static config", async () => {
-      mockUtils(utils, {
-        loadConfig: { packageJson: { name: "fake-package" } },
-      });
-      const deploy = require("../../../src/commands/deploy");
-      await expect(deploy()).rejects.toEqual(ACTION_NO_CONFIG);
+  it("fails if no static config", async () => {
+    mockUtils(utils, {
+      loadConfig: { packageJson: { name: "fake-package" } }
     });
+    const deploy = require("../../../src/commands/deploy");
+    await expect(deploy()).rejects.toEqual(ACTION_NO_CONFIG);
   });
 });

--- a/packages/static/test/commands/deploy/deploy.update.test.js
+++ b/packages/static/test/commands/deploy/deploy.update.test.js
@@ -6,26 +6,13 @@ const {
   mockInquirer,
   mockExeca
 } = require("@designsystemsinternational/cli-utils/test/mock");
+const { defaultFileParams } = require("../../../src/utils");
 
 describe("update", () => {
-  let conf, fileParams;
+  let conf;
   beforeEach(() => {
     mockOra();
     mockInquirer(inquirer);
-    fileParams = [
-      {
-        match: "*.json",
-        params: {
-          ACL: "public-read"
-        }
-      },
-      {
-        match: "*.html",
-        params: {
-          CacheControl: "max-age=500"
-        }
-      }
-    ];
     conf = {
       profile: "fake-profile",
       region: "fake-region",
@@ -34,7 +21,7 @@ describe("update", () => {
         test: {
           stack: "stack-test",
           bucket: "bucket-test",
-          fileParams
+          fileParams: defaultFileParams
         }
       }
     };
@@ -56,6 +43,6 @@ describe("update", () => {
     expect(calls.length).toBe(1);
     expect(calls[0][1]).toEqual("test/fake-package/build");
     expect(calls[0][2]).toEqual("bucket-test");
-    expect(calls[0][3]).toEqual(fileParams);
+    expect(calls[0][3]).toEqual(defaultFileParams);
   });
 });


### PR DESCRIPTION
This PR makes it possible to add basic auth to a website via CloudFront and a Lambda Edge function.

It also adds the ability to run `static deploy --configure` to reprompt the setup questions for the environment. This can also be used to update the config file to the newest version of `static`.