### PR TITLE
Format names for AWS when generating from package.json

### DIFF
--- a/packages/cli-utils/src/index.js
+++ b/packages/cli-utils/src/index.js
@@ -414,6 +414,22 @@ const waitForChangeset = async (
 
 const timeout = ms => new Promise(resolve => setTimeout(resolve, ms));
 
+// ensures the name follows the AWS naming requirements
+// https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html
+const formatAwsName = (name, sufix = "") => {
+  const max = sufix ? 63 - sufix.length : 63;
+  const append = sufix ? `-${sufix}` : "";
+  return (
+    name
+      .replace(/[^a-z0-9.-]/g, "-")
+      .replace(/^[^a-z0-9]/, "")
+      .replace(/-$/, "")
+      .replace(/\.+/g, ".")
+      .replace(/\.*-\.*/g, "-")
+      .slice(0, max) + append
+  );
+};
+
 const newChangesetName = () => {
   const now = new Date();
   return `deploy-${now.getFullYear()}-${now.getMonth() +
@@ -450,6 +466,7 @@ module.exports = {
   assignTemplate,
   monitorStack,
   paramsToInquirer,
+  formatAwsName,
   newChangesetName,
   waitForChangeset,
   log,

--- a/packages/dynamic/src/commands/deploy.js
+++ b/packages/dynamic/src/commands/deploy.js
@@ -17,6 +17,7 @@ const {
   paramsToInquirer,
   zipWebpackOutput,
   uploadFilesToS3,
+  formatAwsName,
   newChangesetName,
   monitorStack,
   waitForChangeset
@@ -74,7 +75,7 @@ const createStack = async (env, packageJson, conf, envConf) => {
       type: "input",
       name: "stack",
       message: `Name of the new Cloudformation stack`,
-      default: `${packageJson.name}-${env}`
+      default: formatAwsName(packageJson.name, env)
     }
   ]);
 

--- a/packages/dynamic/src/commands/init.js
+++ b/packages/dynamic/src/commands/init.js
@@ -6,12 +6,13 @@ const {
   awsRegions,
   checkS3BucketExists,
   getAWSWithProfile,
+  formatAwsName
 } = require("@designsystemsinternational/cli-utils");
 const {
-  INIT_WITH_CONFIG,
+  INIT_WITH_CONFIG
 } = require("@designsystemsinternational/cli-utils/src/constants");
 
-const init = async (args) => {
+const init = async args => {
   const { conf, packageJson } = loadConfig("dynamic");
   if (conf) {
     throw INIT_WITH_CONFIG;
@@ -24,23 +25,25 @@ const init = async (args) => {
     {
       name: "profile",
       type: "input",
-      message: `Which AWS profile would you like to use for this project?`,
+      message: `Which AWS profile would you like to use for this project?`
     },
     {
       name: "region",
       type: "list",
       message: `Which AWS region would you like to use for this project?`,
-      choices: Object.keys(awsRegions).map((k) => ({
+      choices: Object.keys(awsRegions).map(k => ({
         name: awsRegions[k],
-        value: k,
-      })),
+        value: k
+      }))
     },
     {
       name: "bucket",
       type: "input",
       message: `Which bucket name would you like to use for the lambda ZIP files?`,
-      default: packageJson.name ? `${packageJson.name}-operations` : undefined,
-    },
+      default: packageJson.name
+        ? formatAwsName(packageJson.name, "operations")
+        : undefined
+    }
   ]);
 
   const AWS = getAWSWithProfile(aws.profile, aws.region);

--- a/packages/static/src/commands/deploy.js
+++ b/packages/static/src/commands/deploy.js
@@ -54,7 +54,7 @@ const runCloudFormation = async (env, conf, packageJson, envConf) => {
       type: "input",
       name: "stack",
       message: `Name of the new Cloudformation stack`,
-      default: `${packageJson.name}-${env}`,
+      default: formatAwsName(packageJson.name, env),
       when: !envConf || !envConf.stack
     },
     {
@@ -227,7 +227,7 @@ const uploadFiles = async (env, conf, packageJson, envConf, args) => {
         message: `This will deploy the ${chalk.red(
           env
         )} environment. Continue?`,
-        default: `${packageJson.name}-${env}`
+        default: formatAwsName(packageJson.name, env)
       }
     ]);
   }


### PR DESCRIPTION
Package names may include namespacing which contain characters that are illegal for  aws names.

This implements a `cli-utils` function to format the package name with an optional sufix, and uses it whenever names are generated from `packageJson.name`.