### PR TITLE
Fix formatAwsName

### DIFF
--- a/packages/static/src/commands/deploy.js
+++ b/packages/static/src/commands/deploy.js
@@ -13,6 +13,7 @@ const {
   uploadDirToS3,
   paramsToInquirer,
   assignTemplate,
+  formatAwsName,
   log,
   logTable
 } = require("@designsystemsinternational/cli-utils");


### PR DESCRIPTION
This PR actually imports the `formatAwsName` function when deploying 🤓 