### PR TITLE
Fix default s3 bucket name prompt

### DIFF
--- a/packages/scaffold/package.json
+++ b/packages/scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@designsystemsinternational/scaffold",
-  "version": "3.3.9",
+  "version": "3.3.10",
   "description": "Command-line tool to generate a sensible Javascript project scaffold",
   "repository": "github:designsystemsinternational/scaffold",
   "scripts": {

--- a/packages/static/src/commands/deploy.js
+++ b/packages/static/src/commands/deploy.js
@@ -118,9 +118,12 @@ const runCloudFormation = async (env, conf, packageJson, envConf) => {
     S3BucketName: envConf ? envConf.bucket : answers.stack
   };
 
+  // add default S3BucketName to inquirer params
+  template.Parameters.S3BucketName.Default = defaults.S3BucketName;
+
   // Add questions based on Cloudformation parameters
   const templateAnswers = await inquirer.prompt(
-    paramsToInquirer(template.Parameters, defaults)
+    paramsToInquirer(template.Parameters, {})
   );
 
   const label = envConf ? "Updating stack" : "Creating stack";


### PR DESCRIPTION
I noticed the default s3 bucket came out blank when creating a new environment, causing it to fail. This fixes that.