### PR TITLE
Handle cjs file extension

### DIFF
--- a/packages/dynamic/README.md
+++ b/packages/dynamic/README.md
@@ -68,7 +68,6 @@ The `dynamic` config is defined in a `dynamic` key inside the `package.json`. Th
 - `cloudformationMatch`. The glob patterns used to detect cloudformation files. Uses [`micromatch`](https://github.com/micromatch/micromatch) and defaults to `["functions/**/cf.js"]`.
 - `lambdaMatch`. The glob patterns used to detect lambda files. Uses [`micromatch`](https://github.com/micromatch/micromatch) and defaults to `["functions/**/*.js", "!functions/**/cf.js"]`.
 - `buildDir`. Directory where the lambda build files go. Defaults to `build`.
-- `fileExtension`. Extension of the lambda and cloudformation files. Defaults to `js`, if your project is ESM this needs to change to `cjs` so you can corectly use require in your functions.
 
 ## Automatic parameters
 

--- a/packages/dynamic/README.md
+++ b/packages/dynamic/README.md
@@ -68,6 +68,7 @@ The `dynamic` config is defined in a `dynamic` key inside the `package.json`. Th
 - `cloudformationMatch`. The glob patterns used to detect cloudformation files. Uses [`micromatch`](https://github.com/micromatch/micromatch) and defaults to `["functions/**/cf.js"]`.
 - `lambdaMatch`. The glob patterns used to detect lambda files. Uses [`micromatch`](https://github.com/micromatch/micromatch) and defaults to `["functions/**/*.js", "!functions/**/cf.js"]`.
 - `buildDir`. Directory where the lambda build files go. Defaults to `build`.
+- `fileExtension`. Extension of the lambda and cloudformation files. Defaults to `js`, if your project is ESM this needs to change to `cjs` so you can corectly use require in your functions.
 
 ## Automatic parameters
 

--- a/packages/dynamic/src/utils.js
+++ b/packages/dynamic/src/utils.js
@@ -12,7 +12,8 @@ const md5File = require("md5-file");
 const configDefaults = {
   cloudformationMatch: ["functions/**/*cf.js"],
   lambdaMatch: ["functions/**/*.js", "!**/*cf.js", "!**/*.test.js"],
-  buildDir: "build"
+  buildDir: "build",
+  fileExtension: "js"
 };
 
 // Lambda utils
@@ -27,7 +28,7 @@ const getFunctions = async (conf, name) => {
   ]);
   const relFiles = allFiles.map(f => relative(cwd, f));
   const functions = micromatch(relFiles, conf.lambdaMatch).map(f => ({
-    name: basename(f, ".js"),
+    name: basename(f, `.${conf.fileExtension}`),
     path: join(cwd, f)
   }));
   if (name) {

--- a/packages/dynamic/src/utils.js
+++ b/packages/dynamic/src/utils.js
@@ -12,12 +12,23 @@ const md5File = require("md5-file");
 const configDefaults = {
   cloudformationMatch: ["functions/**/*cf.js"],
   lambdaMatch: ["functions/**/*.js", "!**/*cf.js", "!**/*.test.js"],
-  buildDir: "build",
-  fileExtension: "js"
+  buildDir: "build"
 };
 
 // Lambda utils
 // ---------------------------------------------------
+
+const getBaseNameForFunction = fileName => {
+  const allowedExtensions = [".js", ".cjs", ".mjs"];
+
+  for (const ext of allowedExtensions) {
+    if (fileName.endsWith(ext)) {
+      return basename(fileName, ext);
+    }
+  }
+
+  return basename(fileName);
+};
 
 const getFunctions = async (conf, name) => {
   const cwd = process.cwd();
@@ -28,7 +39,7 @@ const getFunctions = async (conf, name) => {
   ]);
   const relFiles = allFiles.map(f => relative(cwd, f));
   const functions = micromatch(relFiles, conf.lambdaMatch).map(f => ({
-    name: basename(f, `.${conf.fileExtension}`),
+    name: getBaseNameForFunction(f),
     path: join(cwd, f)
   }));
   if (name) {
@@ -98,6 +109,7 @@ const compileCloudformationTemplate = async conf => {
 };
 
 module.exports = {
+  getBaseNameForFunction,
   configDefaults,
   compileCloudformationTemplate,
   getFunctions,

--- a/packages/dynamic/test/specs/utils.test.js
+++ b/packages/dynamic/test/specs/utils.test.js
@@ -1,0 +1,24 @@
+const { getBaseNameForFunction } = require("../../src/utils.js");
+
+describe("utils", () => {
+  describe("getBaseNameForFunction", () => {
+    it("correctly figures out the base name for allowed extensions", () => {
+      expect(getBaseNameForFunction("some/nested/path/lambda.js")).toEqual(
+        "lambda"
+      );
+      expect(getBaseNameForFunction("some/nested/path/lambda.cjs")).toEqual(
+        "lambda"
+      );
+      expect(getBaseNameForFunction("some/nested/path/lambda.mjs")).toEqual(
+        "lambda"
+      );
+    });
+
+    // TODO: should we consider throwing, to be on the safe side?
+    it("should pass through non allowed extensions", () => {
+      expect(getBaseNameForFunction("some/nested/path/lambda.ts")).toEqual(
+        "lambda.ts"
+      );
+    });
+  });
+});


### PR DESCRIPTION
Dynamic amazingly already allows to override the glob string to match CF functions. This comes in handy when working in a ESM context, but your functions being CJS.

Additionally I found the need to be able to also overwrite the file extension. I'm sure there is a smarter way to handle this by inferring it from the `package.json` or by inferring it from the `cloudformationMatch`, but for the time being setting it as a config option seemed the quickest and the most pragmatic and explicit.