### PR TITLE
Allow passing in external package array to webpack config

### DIFF
--- a/packages/dynamic/CHANGELOG.md
+++ b/packages/dynamic/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: Let dynamic correctly handle lambda files ending in `.cjs` or `.mjs`
+- Feat: Allow users to pass external module configuration to the webpack config used to build the lambda functions
 
 ## 4.0.1
 

--- a/packages/dynamic/README.md
+++ b/packages/dynamic/README.md
@@ -68,6 +68,7 @@ The `dynamic` config is defined in a `dynamic` key inside the `package.json`. Th
 - `cloudformationMatch`. The glob patterns used to detect cloudformation files. Uses [`micromatch`](https://github.com/micromatch/micromatch) and defaults to `["functions/**/cf.js"]`.
 - `lambdaMatch`. The glob patterns used to detect lambda files. Uses [`micromatch`](https://github.com/micromatch/micromatch) and defaults to `["functions/**/*.js", "!functions/**/cf.js"]`.
 - `buildDir`. Directory where the lambda build files go. Defaults to `build`.
+- `externalPackages`. Optional array of NPM packages used in your functions that you don't want to bundle with your lambda code. This is mostly used for libraries that include a binary (like Puppeteer). Packages relying on binaries are easier to set up using a shared [Lambda Layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 
 ## Automatic parameters
 

--- a/packages/dynamic/src/default.webpack.config.js
+++ b/packages/dynamic/src/default.webpack.config.js
@@ -7,7 +7,7 @@ module.exports = (entries, conf) => {
     mode: "production",
     target: "node",
     entry: entries,
-    externals: ["aws-sdk"],
+    externals: ["aws-sdk", ...conf.externalPackages],
     output: {
       path: path.join(process.cwd(), conf.buildDir),
       libraryTarget: "umd",

--- a/packages/dynamic/src/utils.js
+++ b/packages/dynamic/src/utils.js
@@ -12,7 +12,8 @@ const md5File = require("md5-file");
 const configDefaults = {
   cloudformationMatch: ["functions/**/*cf.js"],
   lambdaMatch: ["functions/**/*.js", "!**/*cf.js", "!**/*.test.js"],
-  buildDir: "build"
+  buildDir: "build",
+  externalPackages: []
 };
 
 // Lambda utils


### PR DESCRIPTION
Another small change to solve a problem I noticed when building the BTG emails. Currently the webpack config is pretty hard coded inside of dynamic. I ran into the situation where I needed to deploy a function that relies on using Puppeteer (via `chrome-aws-lambda`). 

The recommended way to set this up is to use a [lambda layer](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html) so I don't need to ship the Chromium binary with my Lambda function (which would yield another error, as the current webpack config does not handle binaries).

In order to be able to do this I needed a way to add `chrome-aws-lambda` to webpack's external option.

For now I suggest to just pass this forward using a settings option. For the next big release we should consider a more granular way to extend or overwrite parts of dynamics webpack config.